### PR TITLE
Describing `ETHICS_APPLICATIONS_REF` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ following environment variables.
 
 - `HAPLO_API_KEY` - API Key from Haplo 
 - `HAPLO_BASE_URL`  - the base URL of Ethics Monitor. For EUR it is https://ethicsmonitor.eur.nl/
+- `ETHICS_APPLICATIONS_REF` - the REF for ethics applications. For EUR, it is 801w6
 - `ADMIN_USERNAME` - Username for login
 - `ADMIN_PASSWORD` - Password for login
 


### PR DESCRIPTION
This PR adds a description of the needed env variable "ETHICS_APPLICATIONS_REF", used in the hellohaplo package